### PR TITLE
add particle.clMoveParticle() - 1.10 side

### DIFF
--- a/src/main/java/mcjty/lib/compat/CompatParticle.java
+++ b/src/main/java/mcjty/lib/compat/CompatParticle.java
@@ -33,6 +33,6 @@ public class CompatParticle extends Particle {
     }
 	
 	public void clMoveParticle(double x, double y, double z) {
-		moveEntity(x,y,z):
+		moveEntity(x,y,z);
 	}
 }

--- a/src/main/java/mcjty/lib/compat/CompatParticle.java
+++ b/src/main/java/mcjty/lib/compat/CompatParticle.java
@@ -31,4 +31,8 @@ public class CompatParticle extends Particle {
     public void setBoundingBox(AxisAlignedBB bb) {
         clSetBoundingBox(bb);
     }
+	
+	public void clMoveParticle(double x, double y, double z) {
+		moveEntity(x,y,z):
+	}
 }


### PR DESCRIPTION
Added a bridge method called clMoveParticle that forwards the call to moveEntity on 1.10 and to move on 1.11.2